### PR TITLE
Fixes for LLVM base delphi that don't allow assembler

### DIFF
--- a/Source/GR32.inc
+++ b/Source/GR32.inc
@@ -169,6 +169,10 @@
     {$DEFINE OMIT_MMX}
   {$ENDIF}
 
+  {$IFDEF PUREPASCAL}
+    {$DEFINE OMIT_MMX}
+  {$ENDIF}
+
 
 (*
   Symbol OMIT_SSE2:
@@ -182,6 +186,9 @@
 *)
 
   {-$DEFINE OMIT_SSE2}
+  {$IFDEF PUREPASCAL}
+    {$DEFINE OMIT_SSE2}
+  {$ENDIF}
 
 
 (*

--- a/Source/GR32_PolygonsAggLite.pas
+++ b/Source/GR32_PolygonsAggLite.pas
@@ -762,6 +762,7 @@ begin
   until Count = 0;
 end;
 
+{$IFNDEF PUREPASCAL}
 procedure FillSpan_ASM(Ptr: PColor32Array; Covers: PColor32; Count: Cardinal;
   const C: TColor32);
 asm
@@ -872,6 +873,7 @@ asm
         JS      @LoopStart
 {$ENDIF}
 end;
+{$ENDIF !PUREPASCAL}
 
 {$IFNDEF OMIT_MMX}
 {$IFDEF TARGET_X86}


### PR DESCRIPTION
I had some trouble compiling Graphics32 for MacOS64 and Linux64 due to disallowed assembler. Please see my attempted fix. There may be a better way, please feel free to improve. Thanks